### PR TITLE
Session cookie+token to fix search suggestions

### DIFF
--- a/PornhubScript.js
+++ b/PornhubScript.js
@@ -6,7 +6,10 @@ const PLATFORM_CLAIMTYPE = 3;
 const PLATFORM = "PornHub";
 
 var config = {};
-
+// session token
+var token = "";
+// headers (including cookie by default, since it's used for each session later)
+var headers = {"Cookie": ""};
 
 /**
  * Build a query
@@ -42,25 +45,16 @@ source.getHome = function () {
 };
 
 
-//var token = ""
 
 source.searchSuggestions = function(query) {
-
-	//if (token == "") {
-	//	// todo need to always fetch page?
-	//	var html = getPorhubContentData("https://www.pornhub.com");
-	//	var nodes = domParser.parseFromString(html);
-	//	token = nodes.querySelector("div#searchInput").getAttribute("data-token");
-	//}
-	//var url = URL_BASE + "/video/search_autocomplete?pornstars=true&token=" + "MTcwMDY1ODczMfrwOfTXBBSZjUqcT7lVRGoirmVyvPkGLCYGiK_LvwS7ie1LKz-AwcWP_Uh8_mkCZ1M8WegpRzKH_wdQKol3ZoY." + "&orientation=straight&q=" + query + "&alt=0"
-	//return getPorhubContentData(URL_BASE + "/video/search_autocomplete?pornstars=true&token=" + "MTcwMDY1ODczMfrwOfTXBBSZjUqcT7lVRGoirmVyvPkGLCYGiK_LvwS7ie1LKz-AwcWP_Uh8_mkCZ1M8WegpRzKH_wdQKol3ZoY." + "&orientation=straight&q=" + query + "&alt=0")
+	if(query.length < 1) return [];
 	var json = JSON.parse(getPorhubContentData(URL_BASE + "/video/search_autocomplete?pornstars=true&token=" + token + "&orientation=straight&q=" + query + "&alt=0"));
-
-	var channelNames = json.channels.forEach((m) => {
-		return m.name
-	});
-
-	return channelNames
+	if (json.length == 0) return [];
+	var suggestions = json.queries;
+	// var suggestions = json.channels.forEach((m) => {
+	// 	return m.name
+	// });
+	return suggestions
 };
 
 source.getSearchCapabilities = () => {

--- a/PornhubScript.js
+++ b/PornhubScript.js
@@ -1,4 +1,3 @@
-
 const URL_BASE = "https://www.pornhub.com";
 
 const PLATFORM_CLAIMTYPE = 3;

--- a/PornhubScript.js
+++ b/PornhubScript.js
@@ -48,7 +48,7 @@ source.getHome = function () {
 
 source.searchSuggestions = function(query) {
 	if(query.length < 1) return [];
-	var json = JSON.parse(getPorhubContentData(URL_BASE + "/video/search_autocomplete?pornstars=true&token=" + token + "&orientation=straight&q=" + query + "&alt=0"));
+	var json = JSON.parse(getPornhubContentData(URL_BASE + "/video/search_autocomplete?pornstars=true&token=" + token + "&orientation=straight&q=" + query + "&alt=0"));
 	if (json.length == 0) return [];
 	var suggestions = json.queries;
 	// var suggestions = json.channels.forEach((m) => {
@@ -164,7 +164,7 @@ const supportedResolutions = {
 // TODO improve
 source.getContentDetails = function (url) {
 
-	var html = getPorhubContentData(url);
+	var html = getPornhubContentData(url);
 
 	let flashvarsMatch = html.match(/var\s+flashvars_\d+\s*=\s*({.+?});/);
 	let flashvars = {};
@@ -258,7 +258,7 @@ function getVideoId(dom) {
 
 //Comments
 source.getComments = function (url) {
-	var html = getPorhubContentData(url);
+	var html = getPornhubContentData(url);
 	var dom = domParser.parseFromString(html);
 	var videoId = getVideoId(dom);
 	var token = getToken(dom)
@@ -296,7 +296,7 @@ function getCommentPager(path, params, page) {
 	const url = URL_BASE + path;
 	const urlWithParams = `${url}${buildQuery(params)}`;
 
-	var html = getPorhubContentData(urlWithParams);
+	var html = getPornhubContentData(urlWithParams);
 
 	var comments = getComments(html);
 
@@ -436,7 +436,7 @@ function parseRelativeDate(relativeDate) {
 
 
 function getChannelInfo22(url) {
-	var html = getPorhubContentData(url);
+	var html = getPornhubContentData(url);
 	let dom = domParser.parseFromString(html);
 
 	var channelName = ""
@@ -493,7 +493,7 @@ function getChannelInfo22(url) {
 
 // todo forse va bene per pornstar??
 //function getChannelContents(url, ulElement) {
-//	var html = getPorhubContentData(url);
+//	var html = getPornhubContentData(url);
 //	let dom = domParser.parseFromString(html);
 //	
 //
@@ -593,7 +593,7 @@ function getChannelInfo22(url) {
 
 
 function getChannelInfo(url) {
-	var html = getPorhubContentData(url);
+	var html = getPornhubContentData(url);
 	let dom = domParser.parseFromString(html);
 
 	var channelThumbnail = dom.getElementById("getAvatar").getAttribute("src");
@@ -622,7 +622,7 @@ function getChannelInfo(url) {
 
 
 function getPornstarInfo(url) {
-	var html = getPorhubContentData(url);
+	var html = getPornhubContentData(url);
 	let dom = domParser.parseFromString(html);
 
 	var channelName = ""
@@ -739,7 +739,7 @@ function getChannelPager(path, params, page) {
 	const url = URL_BASE + path;
 	const urlWithParams = `${url}${buildQuery(params)}`;
 
-	var html = getPorhubContentData(urlWithParams);
+	var html = getPornhubContentData(urlWithParams);
 
 	var channels = getChannels(html, "searchChannelsSection");
 
@@ -779,7 +779,7 @@ function getChannels(html) {
 
 	var hasNextPage = false; 
 	var pageNextNode = dom.getElementsByClassName("page_next");
-	if (pageNextNode.lenght > 0) {
+	if (pageNextNode.length > 0) {
 		hasNextPage = pageNextNode[0].firstChild.getAttribute("href") == "" ? false : true;
 	}
 
@@ -803,7 +803,7 @@ function getChannelVideosPager(path, params, page) {
 	const url = path;
 	const urlWithParams = `${url}${buildQuery(params)}`;
 
-	var html = getPorhubContentData(urlWithParams);
+	var html = getPornhubContentData(urlWithParams);
 
 	var vids = getChannelContents(html);
 
@@ -882,7 +882,7 @@ function getVideoPager(path, params, page) {
 	const url = URL_BASE + path;
 	const urlWithParams = `${url}${buildQuery(params)}`;
 
-	var html = getPorhubContentData(urlWithParams);
+	var html = getPornhubContentData(urlWithParams);
 
 	var vids = getVideos(html, "videoSearchResult");
 	
@@ -995,7 +995,7 @@ function getVideos(html, ulId) {
 }
 
 
-function getPorhubContentData(url) {
+function getPornhubContentData(url) {
 
 	const resp = http.GET(url, {});
 	if (!resp.isOk)


### PR DESCRIPTION
This adds basic session cookie header to all http.GET requests.
The only things you need for a valid session are as follows:
 1. token
 2. session_id cookie (ss) in headers

I found the cookie using `curl -sS -D - https://www.pornhub.com -o ph.html` and trying every cookie in the response headers, and the only one that will get you a response other than just empty `[]` when you GET /video/search_autocomplete is "ss" aka session_id. Fortunately, this is inside the HTML itself (you can check ph.html output by the command) on every page load along with the token and is super easy to get. It's in `meta[name="adsbytrafficjunkycontext"]` in the `data-info` attribute.

Anyway, all this fixes search suggestions. 

The tokens should last long enough that we don't need any additional logic, but if we do, it would be determining if a token expired when you do a request (in getPornhubContentData) and generating a new one.