### PR TITLE
Fix: downloading, viewing channel/model/pornstar, pagination, some bugs

### DIFF
--- a/PornhubScript.js
+++ b/PornhubScript.js
@@ -324,7 +324,9 @@ function getCommentPager(path, params, page) {
 	var html = getPornhubContentData(urlWithParams);
 
 	var comments = getComments(html);
-
+	// if no comments, return empty pager
+	if (comments.total === 0) return new PornhubCommentPager();
+	
 	return new PornhubCommentPager(comments.comments.map(c => {
 		return new Comment({
 			author: new PlatformAuthorLink(new PlatformID(PLATFORM, c.username, config.id), 

--- a/PornhubScript.js
+++ b/PornhubScript.js
@@ -172,10 +172,10 @@ source.getContentDetails = function (url) {
 	if (flashvarsMatch) {
 		flashvars = JSON.parse(flashvarsMatch[1]);
 	}
-	log(flashvars);
+	//log(flashvars);
 
 	var mediaDefinitions = flashvars["mediaDefinitions"];
-	log(mediaDefinitions);
+	//log(mediaDefinitions);
 	var sources = [];
 
 
@@ -183,7 +183,7 @@ source.getContentDetails = function (url) {
 		if(typeof mediaDefinition.defaultQuality === "boolean") {
 			// sometimes quality is [] instead of a bool or number
 			if(typeof mediaDefinition.quality === "object") continue;
-			log(mediaDefinition.quality)
+			//log(mediaDefinition.quality)
 			let width = supportedResolutions[`${mediaDefinition.quality}`].width;
 			let height = supportedResolutions[`${mediaDefinition.quality}`].height;
 			sources.push(new HLSSource({

--- a/PornhubScript.js
+++ b/PornhubScript.js
@@ -151,11 +151,12 @@ source.isContentDetailsUrl = function(url) {
 
 
 const supportedResolutions = {
-	//'1080p': { width: 1920, height: 1080 },
-	'720p': { width: 1280, height: 720 },
-	'480p': { width: 854, height: 480 },
-	'360p': { width: 640, height: 360 },
-	'144p': { width: 256, height: 144 }
+	'1080': { width: 1920, height: 1080 },
+	'720': { width: 1280, height: 720 },
+	'480': { width: 854, height: 480 },
+	'360': { width: 640, height: 360 },
+	'240': { width: 352, height: 240 },
+	'144': { width: 256, height: 144 }
 };
 
 
@@ -189,8 +190,8 @@ source.getContentDetails = function (url) {
 			sources.push(new VideoUrlSource({
 				name: "mp4",
 				url: mediaDefinition.videoUrl,
-				width: supportedResolutions["720p"].width,
-				height: supportedResolutions["720p"].height,
+				width: supportedResolutions["720"].width,
+				height: supportedResolutions["720"].height,
 				duration: flashvars.video_duration,
 				container: "video/mp4"
 			}));

--- a/Readme.md
+++ b/Readme.md
@@ -30,19 +30,22 @@ Follow this for development [plugin-development.md](https://gitlab.futo.org/vide
 - Channels search
 - Channel subscribe/unsubscribe (partially)
 - Channel info fetch (description, about, its videos)
+- Search suggestions
+- Video download (HLS)
 - Video search
 - Video playback
 - Video info
+- View profiles for models, pornstars, and channels
 - Fetching video comments with like/dislike, avatar, etc. (only non-nested ones)
 
 ## What's not working:
 
 - Subtitles
-- Search suggestions (added facility but don't really know)
-- Video download (added facility but link returns nothing, maybe requires premium?)
+- Video quality selection
 - Per-channel video search
-- Creators can also be models and pornstars, add search, info fetch, etc. like for channels
+- Search filters
 - Premium login
 - ...all the rest
 
 ## Contribute guys!!!
+


### PR DESCRIPTION
Sorry for the huge PR. Let me know what you think, or if there's anything I should change.

### Fixed
 - downloading videos
   - changed video options from mp4 to all HLS
   - named each HLS source the resolution
   - removed mp4 sources (unable to use them for now, maybe we can use them later?)
 - viewing model/pornstar/channel details
   - split `getChannel*` into `getModel*`, `getPornstar*`, and `getChannel*`
 - paginating videos from model/pornstar/channel
 - paginating comments
 - loading comment from deleted user
 - some function names in logging

I ended up implementing all the commented/unimplemented functions except for `getVideosFirstPageNoSearch` which I deleted (it was commented out).